### PR TITLE
MAINT: remove explicit version string in init module.

### DIFF
--- a/pyloras/__init__.py
+++ b/pyloras/__init__.py
@@ -1,5 +1,3 @@
 from ._loras import LORAS
 from ._prowras import ProWRAS
 from ._gamus import GAMUS
-
-__version__ = '0.1.0-beta.5'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,14 +32,11 @@ source = "https://github.com/zoj613/pyloras"
 tracker = "https://github.com/zoj613/pyloras/issues"
 
 [build-system]
-requires = ["wheel", "setuptools>=61.0.0", "setuptools-scm"]
+requires = ["wheel", "setuptools>=61.0.0", "setuptools-scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages = ["pyloras"]
-
-[tool.setuptools.dynamic]
-version = {attr = "pyloras.__version__"}
 
 [tool.setuptools_scm]
 write_to = "pyloras/_version.py"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -e .
-build==0.8.0
+build==0.10.0
+imbalanced-learn==0.10.1
 numpy==1.23.2
-pytest==7.1.2
+pytest==7.3.1
 pytest-cov==4.0.0


### PR DESCRIPTION
This was left over after replacing `poetry` with `setuptools-scm`. This caused issues when releasing a new version. We also update development packages versions.